### PR TITLE
Desktop: Fix `.desktop` file & force refresh

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -107,7 +107,9 @@ if [[ ! -e ~/.joplin/VERSION ]] || [[ $(< ~/.joplin/VERSION) != "$RELEASE_VERSIO
 
        # On some systems this directory doesn't exist by default
        mkdir -p ~/.local/share/applications
-       echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nComment=Joplin for Desktop\nExec=/home/$USER/.joplin/Joplin.AppImage\nIcon=joplin\nStartupWMClass=Joplin\nType=Application\nCategories=Office;\n$APPIMAGE_VERSION" >> ~/.local/share/applications/appimagekit-joplin.desktop
+       echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nComment=Joplin for Desktop\nExec=/home/$USER/.joplin/Joplin.AppImage\nIcon=joplin\nStartupWMClass=Joplin\nType=Application\nCategories=Office;\n#$APPIMAGE_VERSION" >> ~/.local/share/applications/appimagekit-joplin.desktop
+       # Update application icons
+       [[ `command -v update-desktop-database` ]] && update-desktop-database ~/.local/share/applications
        print "${COLOR_GREEN}OK${COLOR_RESET}"
     else
        print "${COLOR_RED}NOT DONE${COLOR_RESET}"


### PR DESCRIPTION
Version in the desktop file caused parsing errors. Also, force the app file to be loaded/reloaded.
